### PR TITLE
When receiving an empty api response, only reset the measurements.

### DIFF
--- a/luftdaten/__init__.py
+++ b/luftdaten/__init__.py
@@ -43,7 +43,8 @@ class Luftdaten(object):
             raise exceptions.LuftdatenConnectionError()
 
         if not self.data:
-            self.values = self.meta = None
+            for measurement in self.values.keys():
+                self.values[measurement] = None
             return
 
         try:


### PR DESCRIPTION
Currently all measurement keys are removed when receiving an empty
response. The object will not recover from this and will log
an exception when accessing `self.values.keys()` on a subsequent,
succesful, response.

This should solve the following exception:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/homeassistant/components/luftdaten/__init__.py", line 145, in refresh_sensors
    await luftdaten.async_update()
  File "/usr/local/lib/python3.6/site-packages/homeassistant/components/luftdaten/__init__.py", line 185, in async_update
    await self.client.get_data()
  File "/usr/local/lib/python3.6/site-packages/luftdaten/__init__.py", line 62, in get_data
    for measurement in self.values.keys():
AttributeError: 'NoneType' object has no attribute 'keys'
```
