### PR TITLE
Only add value types if reported by the API

### DIFF
--- a/luftdaten/__init__.py
+++ b/luftdaten/__init__.py
@@ -20,10 +20,7 @@ class Luftdaten(object):
         self._session = session
         self.sensor_id = sensor_id
         self.data = None
-        self.values = {
-            'P1': None,
-            'P2': None,
-        }
+        self.values = {}
         self.meta = {}
         self.url = '{}/{}'.format(_RESOURCE, 'sensor')
 
@@ -53,6 +50,8 @@ class Luftdaten(object):
                 reverse=True)[0]
 
             for entry in sensor_data['sensordatavalues']:
+                if entry['value_type'] not in self.values.keys():
+                    self.values[entry['value_type']] = None
                 for measurement in self.values.keys():
                     if measurement == entry['value_type']:
                         self.values[measurement] = float(entry['value'])


### PR DESCRIPTION
The module has P1 and P2 by default, even when the sensor doesn't support it. This will only add those value types that are received by the API response.

should fix https://github.com/home-assistant/home-assistant/issues/25159