### PR TITLE
Use new API endpoint

### DIFF
--- a/luftdaten/__init__.py
+++ b/luftdaten/__init__.py
@@ -8,7 +8,7 @@ import async_timeout
 from . import exceptions
 
 _LOGGER = logging.getLogger(__name__)
-_RESOURCE = 'https://api.luftdaten.info/v1'
+_RESOURCE = 'https://data.sensor.community/airrohr/v1'
 
 
 class Luftdaten(object):


### PR DESCRIPTION
Fixes #7 - although, currently, the old API endpoint seems to redirect to the new one on the remote side.