### PR TITLE
Fix API connection error handling

### DIFF
--- a/luftdaten/__init__.py
+++ b/luftdaten/__init__.py
@@ -29,6 +29,10 @@ class Luftdaten(object):
                 response = await client.get(str(url))
         except httpx.ConnectError:
             raise exceptions.LuftdatenConnectionError(f"Connection to {url} failed")
+        except httpx.ConnectTimeout:
+            raise exceptions.LuftdatenConnectionError(f"Connection to {url} timed out")
+        except httpx.ReadTimeout:
+            raise exceptions.LuftdatenConnectionError(f"Read timeout from {url}")
 
         if response.status_code == httpx.codes.OK:
             try:

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -4,12 +4,29 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from luftdaten import Luftdaten
+from luftdaten.exceptions import LuftdatenConnectionError
 
 SENSOR_ID = 1
 
 @pytest.mark.asyncio
-async def test_timeout(httpx_mock: HTTPXMock):
-    """Test if the connection is hitting the timeout."""
+async def test_connect_timeout(httpx_mock: HTTPXMock):
+    """Test if the connection is hitting the timeout during connect."""
+
+    def raise_timeout(request):
+        """Set the timeout for the requests."""
+        raise httpx.ConnectTimeout(
+            f"Unable to connect within {request.extensions['timeout']}", request=request
+        )
+
+    httpx_mock.add_callback(raise_timeout)
+
+    with pytest.raises(LuftdatenConnectionError):
+        client = Luftdaten(SENSOR_ID)
+        await client.get_data()
+
+@pytest.mark.asyncio
+async def test_read_timeout(httpx_mock: HTTPXMock):
+    """Test if the connection is hitting the timeout during data reading."""
 
     def raise_timeout(request):
         """Set the timeout for the requests."""
@@ -19,6 +36,6 @@ async def test_timeout(httpx_mock: HTTPXMock):
 
     httpx_mock.add_callback(raise_timeout)
 
-    with pytest.raises(httpx.ReadTimeout):
+    with pytest.raises(LuftdatenConnectionError):
         client = Luftdaten(SENSOR_ID)
         await client.get_data()


### PR DESCRIPTION
There are two `httpx` exceptions that needs to be catch. After this patch there will be no traceback prints in HomeAssistant log but just error messages. It doesn't make API more stable but makes log clean. I intentionally put different messages to the exception, however HA doesn't show these errors but just `Unable to retrieve data from Sensor.Community`

Fixes #12
Fixes home-assistant/core/issues/61687